### PR TITLE
Not to display tabs slider

### DIFF
--- a/material-design-for-devtools/material-design-theme.css
+++ b/material-design-for-devtools/material-design-theme.css
@@ -2932,6 +2932,10 @@ label.checkbox,
   border-top: none !important;
   border-bottom: #b1bdc4 !important;
 }
+.tabbed-pane-tab-slider,
+::shadow .tabbed-pane-tab-slider {
+  display: none !important;
+}
 body .toolbar-background,
 body.undocked.platform-mac-mountain-lion.inactive .toolbar-background,
 body.undocked.platform-mac-mountain-lion .toolbar-background,


### PR DESCRIPTION
The tabs slider in my browser is shifted a bit and also I don't see it on screenshots in Chrome Web Store so I decided to remove it.

![Screenshot of Dev Tools with shifted slider](https://cloud.githubusercontent.com/assets/3265335/12003149/16dd6864-ab25-11e5-8481-fc6548823251.png)
